### PR TITLE
Add common label on app-key secret

### DIFF
--- a/snipeit/templates/generate-app-key.yaml
+++ b/snipeit/templates/generate-app-key.yaml
@@ -61,7 +61,14 @@ spec:
             fi
 
             echo "Create secret..."
-            kubectl create secret generic $SECRET_NAME --from-literal=APP_KEY="$APP_KEY"
+            kubectl create secret generic $SECRET_NAME --from-literal=APP_KEY="$APP_KEY" \
+              -l "helm.sh/chart={{ include "snipeit.chart" . }}" \
+              -l "app.kubernetes.io/name={{ include "snipeit.name" . }}" \
+              -l "app.kubernetes.io/instance={{ .Release.Name }}" \
+              {{- if .Chart.AppVersion }}
+              -l "app.kubernetes.io/version={{ .Chart.AppVersion }}" \
+              {{- end }}
+              -l "app.kubernetes.io/managed-by={{ .Release.Service }}"
             echo "Secret created"
 
         volumeMounts:

--- a/snipeit/templates/generate-app-key.yaml
+++ b/snipeit/templates/generate-app-key.yaml
@@ -61,15 +61,18 @@ spec:
             fi
 
             echo "Create secret..."
-            kubectl create secret generic $SECRET_NAME --from-literal=APP_KEY="$APP_KEY" \
-              -l "helm.sh/chart={{ include "snipeit.chart" . }}" \
-              -l "app.kubernetes.io/name={{ include "snipeit.name" . }}" \
-              -l "app.kubernetes.io/instance={{ .Release.Name }}" \
+            kubectl create secret generic $SECRET_NAME --from-literal=APP_KEY="$APP_KEY"
+            
+            echo "Add labels to secret..."
+            kubectl label secret $SECRET_NAME \
+              "helm.sh/chart={{ include "snipeit.chart" . }}" \
+              "app.kubernetes.io/name={{ include "snipeit.name" . }}" \
+              "app.kubernetes.io/instance={{ .Release.Name }}" \
               {{- if .Chart.AppVersion }}
-              -l "app.kubernetes.io/version={{ .Chart.AppVersion }}" \
+              "app.kubernetes.io/version={{ .Chart.AppVersion }}" \
               {{- end }}
-              -l "app.kubernetes.io/managed-by={{ .Release.Service }}"
-            echo "Secret created"
+              "app.kubernetes.io/managed-by={{ .Release.Service }}"
+            echo "Secret created and labeled"
 
         volumeMounts:
         - name: shared-data


### PR DESCRIPTION
To identify all elements created by the Helm chart on K8S, the app-key secret used by Snipe-IT need to have the common tags used by all other elements.