### PR TITLE
SnipeIT: Add support for using an _external_ database

### DIFF
--- a/snipeit/Chart.yaml
+++ b/snipeit/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/Syntax3rror404/helm-charts
 icon: https://github.com/snipe/snipe-it/blob/eb9cfbaed6fc830e9b114c625896a636842f2d1a/public/img/demo/snipe-logo-bug.png?raw=true
 
 type: application
-version: 1.2.10
+version: 1.2.11
 appVersion: "8.2.1"
 
 keywords:
@@ -22,3 +22,4 @@ dependencies:
   - name: mariadb
     version: "21.0.3"
     repository: "oci://registry-1.docker.io/bitnamicharts"
+    condition: mariadb.enabled

--- a/snipeit/templates/statefulset.yaml
+++ b/snipeit/templates/statefulset.yaml
@@ -54,6 +54,13 @@ spec:
           image: "{{ .Values.snipeit.image.repository }}:{{ .Values.snipeit.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.snipeit.image.pullPolicy }}
           env:
+            {{- if and .Values.mariadb.enabled .Values.externalDB.enabled }}
+            {{- fail "You have enabled BOTH .Values.mariadb.enabled and .Values.externalDB.enabled. That is wrong. Please choose one or the other." }}
+            {{- end }}
+            {{- if not (or .Values.mariadb.enabled .Values.externalDB.enabled) }}
+            {{ fail "You need to enable exactly ONE of .Values.mariadb.enabled and .Values.externalDB.enabled so we know how to connect to the database." }}
+            {{- end }}
+            {{- if .Values.mariadb.enabled }}
             - name: DB_USERNAME 
               value: "{{ .Values.mariadb.auth.username }}"
             - name: DB_PASSWORD 
@@ -62,6 +69,16 @@ spec:
               value: "{{ .Values.mariadb.auth.database }}"
             - name: DB_HOST 
               value: "{{ .Release.Name }}-mariadb"
+            {{- else if .Values.externalDB.enabled }}
+            - name: DB_USERNAME
+              {{- .Values.externalDB.username | toYaml | nindent 14 }}
+            - name: DB_PASSWORD
+              {{- .Values.externalDB.password | toYaml | nindent 14 }}
+            - name: DB_DATABASE
+              {{- .Values.externalDB.database | toYaml | nindent 14 }}
+            - name: DB_HOST
+              {{- .Values.externalDB.host | toYaml | nindent 14 }}
+            {{- end }}
             - name: APP_KEY 
               valueFrom:
                 secretKeyRef:

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -3,6 +3,9 @@ updateStrategy: RollingUpdate
 
 # MariaDB
 mariadb:
+  # enabled: If enabled, then a new install of mariadb will be
+  # included.
+  enabled: true
   global:
     defaultStorageClass: "longhorn"
   auth:
@@ -10,6 +13,74 @@ mariadb:
     database: "snipeit"
     username: "snipeit"
     password: "snipeitdbsecret"
+
+# externalDB: Use an "external" database (i.e. not supplied by this
+# chart).
+externalDB:
+  # enabled: Whether to use an external database. If set, then
+  # mariadb.enabled must be set to false.
+  enabled: false
+
+  # username: See pod.spec.containers.env for syntax.
+  username: {}
+  # E.g.
+  # value: "TheUserNameHere"
+  # or
+  # valueFrom:
+  #   secretKeyRef:
+  #     name: name-of-secret
+  #     key: username
+  # or:
+  # valueFrom:
+  #   configMapKeyRef:
+  #     name: name-of-configmap
+  #     key: username
+
+  # password: See pod.spec.containers.env for syntax.
+  password: {}
+  # E.g.
+  # value: "If the password goes here it will be visible in the pod spec"
+  # or:
+  # valueFrom:
+  #   secretKeyRef:
+  #     name: name-of-secret
+  #     key: password
+  # or (you really should not be storing passwords in ConfigMaps,
+  # but it is _your_ system...):
+  # valueFrom:
+  #   configMapKeyRef:
+  #     name: name-of-configmap
+  #     key: password
+
+  # database: See pod.spec.containers.env for syntax.
+  database: {}
+  # E.g.
+  # value: "NameOfDatabase"
+  # or
+  # valueFrom:
+  #   secretKeyRef:
+  #     name: name-of-secret
+  #     key: dbname
+  # or:
+  # valueFrom:
+  #   configMapKeyRef:
+  #     name: name-of-configmap
+  #     key: dbname
+
+  # host: See pod.spec.containers.env for syntax.
+  host: {}
+  # E.g.
+  # value: "someDnsName.example.com"
+  # or
+  # valueFrom:
+  #   secretKeyRef:
+  #     name: name-of-secret
+  #     key: user
+  # or:
+  # valueFrom:
+  #   configMapKeyRef:
+  #     name: name-of-configmap
+  #     key: user
 
 # snipeit config
 snipeit:


### PR DESCRIPTION
i.e. a database not supplied by this chart.

Rationale: Multiple reasons:

- The bitnami charts are going away, so we cannot rely on using them in the future: https://github.com/bitnami/charts/issues/35164
- If people use e.g. mariadb-operator ( https://github.com/mariadb-operator/mariadb-operator ), it would be nice to be able to support that
- When deploying in a cloud environment, users may want to use a MySQL/MariaDB instance provided by the cloud provider

The chart will still default to use the bitnami mariadb chart for backward compatibility, so for existing users: nothing will change.