### PR TITLE
Fix up externaldb usage

### DIFF
--- a/snipeit/templates/statefulset.yaml
+++ b/snipeit/templates/statefulset.yaml
@@ -63,13 +63,13 @@ spec:
             
             {{- if .Values.externalDB.enabled }}
             - name: DB_USERNAME
-              value: "{{- .Values.externalDB.username }}"
+              {{- .Values.externalDB.username | toYaml | nindent 14 }}
             - name: DB_PASSWORD
-              value: "{{- .Values.externalDB.password }}"
+              {{- .Values.externalDB.password | toYaml | nindent 14 }}
             - name: DB_DATABASE
-              value: "{{- .Values.externalDB.database }}"
+              {{- .Values.externalDB.database | toYaml | nindent 14 }}
             - name: DB_HOST
-              value: "{{- .Values.externalDB.host }}"
+              {{- .Values.externalDB.host | toYaml | nindent 14 }}
             {{- end }}
             {{- if .Values.mariadbOperator.enabled }}
             - name: DB_USERNAME

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -85,12 +85,12 @@ externalDB:
   # valueFrom:
   #   secretKeyRef:
   #     name: name-of-secret
-  #     key: user
+  #     key: host
   # or:
   # valueFrom:
   #   configMapKeyRef:
   #     name: name-of-configmap
-  #     key: user
+  #     key: host
 
 # snipeit config
 snipeit:


### PR DESCRIPTION
The idea is to allow users to specify things via a Secret or ConfigMap or (if they desire to) a directly quoted value.

This broke in commit 2a77ca76bf7908dd527739cb09c4c4d8e81fbb0f 