### PR TITLE
Install MariaDB objects only on first install

### DIFF
--- a/keycloak/templates/mariadb-operator.yaml
+++ b/keycloak/templates/mariadb-operator.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.mariadbOperator.enabled }}
-{{- if not .Values.mariadbOperator.useExisting.enabled }}
+{{- if and .Values.mariadbOperator.enabled (not .Values.mariadbOperator.useExisting.enabled) .Release.IsInstall }}
 ---
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: MariaDB
@@ -27,7 +26,6 @@ spec:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
-{{- end }}
 ---
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database


### PR DESCRIPTION
PROBLEM
Helm upgrade fails due to immutable MariaDB Operator CR fields. Upgrading this chart fails after the initial install because it manages MariaDB operator objects that contain immutable fields. On helm upgrade, the MariaDB operator admission webhooks reject the update, making upgrades impossible without manual intervention.

SOLUTION
With this change Helm won't manage the MariaDB operator objects after the first installation