### PR TITLE
feat: Add support for automatically generating cert-manager certificates

### DIFF
--- a/mumble/README.md
+++ b/mumble/README.md
@@ -115,6 +115,14 @@ kubectl delete ns mumble
 |-----------|---------|-------------|
 | `customLabels` | `{}` | Additional labels for all resources |
 
+### Certification Generation
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `certificate.generate` | `false` | Generate a certificate with cert-manager |
+| `certificate.spec.dnsNames` | `[]` | A list of DNS names to generate certificates for |
+| `certificate.spec.issuerRef` | `{}` | A cert-manager reference to the Issuer or ClusterIssuer to use |
+
 ## Configuration Examples
 
 ### Example 1: Basic Mumble Server with Persistence
@@ -198,6 +206,21 @@ persistence:
 
 service:
   type: NodePort
+```
+
+### Example 5: Using Cert Manager for generating certificates
+
+```yaml
+# myvalues.yaml
+certificate:
+  generate: true
+  spec:
+    issuerRef:
+      group: cert-manager.io
+      kind: ClusterIssuer
+      name: my-cluster-issuer
+    dnsNames:
+      - "foo.example.com"
 ```
 
 ### Network Ports

--- a/mumble/templates/certificate.yaml
+++ b/mumble/templates/certificate.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.certificate.generate }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "mumble.fullname" . }}-crt
+  labels:
+    {{- include "mumble.labels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  secretName: {{ include "mumble.fullname" . }}-crt
+  usages:
+    - digital signature
+    - key encipherment
+  {{- with .Values.certificate.spec.dnsNames }}
+  dnsNames:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.certificate.spec.issuerRef }}
+  issuerRef:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/mumble/templates/statefulset.yaml
+++ b/mumble/templates/statefulset.yaml
@@ -50,6 +50,12 @@ spec:
             - name: MUMBLE_CUSTOM_CONFIG_FILE
               value: {{ .Values.environment.customConfigFile | quote }}
             {{- end }}
+            {{- if .Values.certificate.generate }}
+            - name: MUMBLE_CONFIG_SSL_CERT
+              value: "/certs/tls.crt"
+            - name: MUMBLE_CONFIG_SSL_KEY
+              value: "/certs/tls.key"
+            {{- end }}
             - name: MUMBLE_SUPERUSER_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -58,6 +64,10 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+          {{- if .Values.certificate.generate }}
+            - name: certificate
+              mountPath: /certs
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -72,10 +82,17 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if not .Values.persistence.enabled }}
+      {{- if or (not .Values.persistence.enabled) (.Values.certificate.generate) }}
       volumes:
+        {{- if not .Values.persistence.enabled }}
         - name: data
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.certificate.generate }}
+        - name: certificate
+          secret:
+            secretName: {{ include "mumble.fullname" . }}-crt
+        {{- end }}
       {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:

--- a/mumble/values.yaml
+++ b/mumble/values.yaml
@@ -48,6 +48,18 @@ superuserPassword:
   generate: true
   length: 16
 
+certificate:
+  generate: false
+  existingSecret: ""
+  spec:
+    dnsNames: []
+      # dnsNames:
+      #   - mumble.example.com
+    issuerRef: {}
+      #   group: cert-manager.io
+      #   kind: ClusterIssuer
+      #   name: cluster-issuer-name
+
 resources: {}
   # limits:
   #   cpu: 100m


### PR DESCRIPTION
This adds support for generating a certificate through [cert-manager](https://cert-manager.io/), a common system for generating certificates. I have added instructions on usage in the README and automatically generate configuration for `sslCert` and `sslKey` in the mumble server config.