### PR TITLE
Add extra env var injection support for Snipe-IT

### DIFF
--- a/snipeit/templates/statefulset.yaml
+++ b/snipeit/templates/statefulset.yaml
@@ -97,6 +97,9 @@ spec:
               value: "{{ .Values.snipeit.config.timezone }}"
             - name: APP_LOCALE
               value: "{{ .Values.snipeit.config.locale }}"
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/snipeit/values.yaml
+++ b/snipeit/values.yaml
@@ -194,3 +194,20 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Extra environment variables to inject into the container
+# Example:
+# extraEnv:
+#   - name: MY_VAR
+#     value: "my-value"
+#   - name: MY_SECRET_VAR
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: secret-key
+#   - name: MY_CONFIGMAP_VAR
+#     valueFrom:
+#       configMapKeyRef:
+#         name: my-configmap
+#         key: config-key
+extraEnv: []


### PR DESCRIPTION
The SnipeIT helm chart doesn't allow for environment variable injection currently which could be needed for setting certain config settings [listed out in their docs](https://snipe-it.readme.io/docs/configuration).

This change allows additional variables to be set in it